### PR TITLE
Avoid deprecation warning for atom-workspace

### DIFF
--- a/keymaps/git-difftool.cson
+++ b/keymaps/git-difftool.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.platform-darwin, .workspace':
+'.platform-darwin, atom-workspace':
   'ctrl-shift-d': 'git-difftool:diff-project'
   'alt-ctrl-d': 'git-difftool:diff-file'


### PR DESCRIPTION
My version of Atom 0.184.0 gives a Deprecation warning:  ```Use the `atom-workspace` tag instead of the `workspace` class.``` for this plugin. 

Removing the . fixes the warning.