### PR TITLE
Launch the GUI difftool instead of the default

### DIFF
--- a/lib/git-difftool.coffee
+++ b/lib/git-difftool.coffee
@@ -16,4 +16,4 @@ module.exports =
 
   openDifftool: (path) ->
     base = atom.project.getPaths()[0]
-    exec "cd #{base} && git difftool --no-prompt #{path}" if base?
+    exec "cd #{base} && git difftool --gui --no-prompt #{path}" if base?


### PR DESCRIPTION
Git configuration has two difftools, e.g. mine is:

```
[diff]
  tool = vimdiff
  guitool = meld
```

The default one is often a command-line program, so from Atom we need to be launching the GUI tool instead. This is done by passing the `--gui` flag to `git difftool`.
